### PR TITLE
Add Road Registrator, Road Data Gatherer, and Emission Color class for roads

### DIFF
--- a/TrafficSimulator/Assets/AutoDrive/AutoDrive.cs
+++ b/TrafficSimulator/Assets/AutoDrive/AutoDrive.cs
@@ -65,7 +65,7 @@ namespace VehicleBrain
         }
 
         [Header("Connections")]
-        public Road Road;
+        [SerializeField] private Road _road;
         public GameObject NavigationTargetMarker;
         public Material NavigationPathMaterial;
         public int LaneIndex = 0;
@@ -101,6 +101,9 @@ namespace VehicleBrain
         
         // Public variables
         [HideInInspector] public LaneNode CustomStartNode = null;
+        // Used for road registration
+        [HideInInspector] public delegate void RoadChangedDelegate(Road newRoad);
+        [HideInInspector] public RoadChangedDelegate OnRoadChanged;
 
         // Private variables
         private float _vehicleLength;
@@ -135,6 +138,12 @@ namespace VehicleBrain
         private float _targetLerpSpeed = 0;
         private float _timeElapsedSinceLastTarget = 0;
         private float _lastLerpTime = 0;
+
+        public Road Road
+        {
+            get => _road;
+            set => SetRoad(value);
+        }
 
         void Start()
         {
@@ -238,6 +247,15 @@ namespace VehicleBrain
             
             if (ShowTargetLines != ShowTargetLines.None)
                 DrawTargetLines();
+        }
+
+        private void SetRoad(Road newRoad)
+        {
+            if (_road != newRoad)
+            {
+                _road = newRoad;
+                OnRoadChanged?.Invoke(_road);
+            }
         }
 
         private void UpdateIndicators()

--- a/TrafficSimulator/Assets/AutoDrive/AutoDriveEditor.cs
+++ b/TrafficSimulator/Assets/AutoDrive/AutoDriveEditor.cs
@@ -33,7 +33,7 @@ namespace CarGenerator
         #endregion
         public void OnEnable()
         {
-            _road = serializedObject.FindProperty("Road");
+            _road = serializedObject.FindProperty("_road");
             _laneIndex = serializedObject.FindProperty("LaneIndex");
             _mode = serializedObject.FindProperty("Mode");
             _endBehaviour = serializedObject.FindProperty("EndBehaviour");

--- a/TrafficSimulator/Assets/Prefabs/Car/Bus.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Bus.prefab
@@ -1832,6 +1832,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 3615402764517280270}
   m_Layer: 0
   m_Name: Bus
   m_TagString: Untagged
@@ -1874,6 +1875,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2580a7b7136a884391ea27188b7c208, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  BusRoute: []
 --- !u!114 &1577973480145491502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1886,7 +1888,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1895,8 +1897,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 3
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1906,6 +1906,11 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
+  LogNavigationErrors: 0
+  LogBrakeReason: 0
+  _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2373,6 +2378,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2407,6 +2413,18 @@ MonoBehaviour:
   - {fileID: 1107469039499343399}
   - {fileID: 6371984343124634957}
   _intervalTime: 0.5
+--- !u!114 &3615402764517280270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899416901
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/FuelConsumption.cs
+++ b/TrafficSimulator/Assets/Prefabs/Car/FuelConsumption.cs
@@ -29,7 +29,7 @@ namespace VehicleBrain {
         private Rigidbody _rigidbody;
         public float _maxFuelCapacity = 60; // L
         public double _totalFuelConsumed = 0;
-        private float _fuelConsumed = 0;
+        public float FuelConsumedSinceLastFrame = 0;
         private Vector3 _lastPosition = Vector3.zero;
 
         // Vehicle specific values used in the fuel consumption calculation
@@ -87,21 +87,21 @@ namespace VehicleBrain {
             // If the vehicle is not moving, calculate the fuel consumed at idle per second
             if (_vehicleController.speed < 0.1f)
             {
-                _fuelConsumed = _fuelConsumptionAtIdle * Time.deltaTime / 3600;
+                FuelConsumedSinceLastFrame = _fuelConsumptionAtIdle * Time.deltaTime / 3600;
             }
             // If the vehicle is moving at a low speed, calculate the fuel consumed at city speed per 100km
             else if (_vehicleController.speed < 20)
             {
                 float distance = Vector3.Distance(_lastPosition, transform.position);
-                _fuelConsumed = _fuelConsumptionCity * distance / 100000;
+                FuelConsumedSinceLastFrame = _fuelConsumptionCity * distance / 100000;
             }
             // If the vehicle is moving at a high speed, calculate the fuel consumed at highway speed per 100km
             else
             {
                 float distance = Vector3.Distance(_lastPosition, transform.position);
-                _fuelConsumed = _fuelConsumptionHighway * distance / 100000;
+                FuelConsumedSinceLastFrame = _fuelConsumptionHighway * distance / 100000;
             }
-            _totalFuelConsumed += _fuelConsumed;
+            _totalFuelConsumed += FuelConsumedSinceLastFrame;
         }
 
         private void Q_CalculateFuelConsumption()
@@ -117,8 +117,8 @@ namespace VehicleBrain {
             _averageAcceleration = MathF.Max((_vehicleController.speed - _lastSpeed) /Time.deltaTime, 0);
 
             // Calculate the fuel consumed since last frame and add it to the total fuel consumed
-            _fuelConsumed = MathF.Max(_averageAcceleration * Time.deltaTime / 1000, _idleFuelConsumption * Time.deltaTime);
-            _totalFuelConsumed += _fuelConsumed;
+            FuelConsumedSinceLastFrame = MathF.Max(_averageAcceleration * Time.deltaTime / 1000, _idleFuelConsumption * Time.deltaTime);
+            _totalFuelConsumed += FuelConsumedSinceLastFrame;
         }
 
         private void Q_CalculateIdleFuelConsumption()

--- a/TrafficSimulator/Assets/Prefabs/Car/Sedan.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Sedan.prefab
@@ -1832,6 +1832,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 4552512951152379661}
   m_Layer: 0
   m_Name: Sedan
   m_TagString: Untagged
@@ -1886,7 +1887,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1895,8 +1896,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1906,6 +1905,11 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
+  LogNavigationErrors: 0
+  LogBrakeReason: 0
+  _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2373,6 +2377,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2407,6 +2412,18 @@ MonoBehaviour:
   - {fileID: 1107469039499343399}
   - {fileID: 6371984343124634957}
   _intervalTime: 0.5
+--- !u!114 &4552512951152379661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899416901
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/SportsCar1.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/SportsCar1.prefab
@@ -3040,6 +3040,7 @@ GameObject:
   - component: {fileID: 5247432408191570248}
   - component: {fileID: 3204221514871440517}
   - component: {fileID: 3757735537286086049}
+  - component: {fileID: 680520665737247066}
   m_Layer: 0
   m_Name: SportsCar1
   m_TagString: Untagged
@@ -3083,7 +3084,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -3092,8 +3093,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -3103,7 +3102,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &6380633828474830392
 Rigidbody:
@@ -3584,6 +3586,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &3204221514871440517
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3618,6 +3621,18 @@ MonoBehaviour:
   - {fileID: 4770441295206356650}
   - {fileID: 1515271969563708864}
   _intervalTime: 0.5
+--- !u!114 &680520665737247066
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6380633828477897570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6380633828477908988
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/SportsCar2.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/SportsCar2.prefab
@@ -2446,6 +2446,7 @@ GameObject:
   - component: {fileID: 5247432408191570248}
   - component: {fileID: 3204221514871440517}
   - component: {fileID: 3757735537286086049}
+  - component: {fileID: 3794487503024328321}
   m_Layer: 0
   m_Name: SportsCar2
   m_TagString: Untagged
@@ -2488,7 +2489,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -2497,8 +2498,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -2508,7 +2507,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &6380633828474830392
 Rigidbody:
@@ -2989,6 +2991,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &3204221514871440517
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3023,6 +3026,18 @@ MonoBehaviour:
   - {fileID: 5673745709147014360}
   - {fileID: 3605473524867714953}
   _intervalTime: 0.5
+--- !u!114 &3794487503024328321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6380633828477897570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6380633828477908988
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/Suv1.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Suv1.prefab
@@ -1551,6 +1551,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 2400971864072765794}
   m_Layer: 0
   m_Name: Suv1
   m_TagString: Untagged
@@ -1595,7 +1596,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1604,8 +1605,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1615,7 +1614,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
@@ -2096,6 +2098,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2130,6 +2133,18 @@ MonoBehaviour:
   - {fileID: 941272425479982803}
   - {fileID: 6495108265532741049}
   _intervalTime: 0.5
+--- !u!114 &2400971864072765794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899420503
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/Suv2.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Suv2.prefab
@@ -1630,6 +1630,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 6179465781180024847}
   m_Layer: 0
   m_Name: Suv2
   m_TagString: Untagged
@@ -1674,7 +1675,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1683,8 +1684,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1694,7 +1693,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
@@ -2175,6 +2177,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2209,6 +2212,18 @@ MonoBehaviour:
   - {fileID: 1107469039499343399}
   - {fileID: 6371984343124634957}
   _intervalTime: 0.5
+--- !u!114 &6179465781180024847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899420503
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/Van1.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Van1.prefab
@@ -1694,6 +1694,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 7759013039122067897}
   m_Layer: 0
   m_Name: Van1
   m_TagString: Untagged
@@ -1738,7 +1739,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1747,8 +1748,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1758,7 +1757,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
@@ -2239,6 +2241,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2273,6 +2276,18 @@ MonoBehaviour:
   - {fileID: 4088012803037771231}
   - {fileID: 8036912380573265589}
   _intervalTime: 0.5
+--- !u!114 &7759013039122067897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899420503
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Prefabs/Car/Van2.prefab
+++ b/TrafficSimulator/Assets/Prefabs/Car/Van2.prefab
@@ -1444,6 +1444,7 @@ GameObject:
   - component: {fileID: 412107769271382469}
   - component: {fileID: 6997793727484486664}
   - component: {fileID: 8740552995654376748}
+  - component: {fileID: 1571543004753185472}
   m_Layer: 0
   m_Name: Van2
   m_TagString: Untagged
@@ -1488,7 +1489,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ed2077f9a1d00454da03e178dd2ee3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Road: {fileID: 0}
+  _road: {fileID: 0}
   NavigationTargetMarker: {fileID: 7023115232937241705, guid: aefc060f78374b74d90bb7c5c444d6ab, type: 3}
   NavigationPathMaterial: {fileID: 0}
   LaneIndex: 0
@@ -1497,8 +1498,6 @@ MonoBehaviour:
   EndBehaviour: 0
   ShowNavigationPath: 0
   OriginalNavigationMode: 2
-  LogRepositioningInformation: 0
-  ShowTargetLines: 4
   BrakeOffset: 3
   MaxRepositioningSpeed: 5
   MaxReverseDistance: 20
@@ -1508,7 +1507,10 @@ MonoBehaviour:
   Speed: 10
   Acceleration: 7
   TotalDistance: 0
+  ShowTargetLines: 4
+  LogRepositioningInformation: 0
   LogNavigationErrors: 0
+  LogBrakeReason: 0
   _logParkingFull: 0
 --- !u!54 &1577973480894095029
 Rigidbody:
@@ -1989,6 +1991,7 @@ MonoBehaviour:
   _idlingRPM: 650
   _maxFuelCapacity: 60
   _totalFuelConsumed: 0
+  FuelConsumedSinceLastFrame: 0
 --- !u!114 &6997793727484486664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2023,6 +2026,18 @@ MonoBehaviour:
   - {fileID: 1107469039499343399}
   - {fileID: 6371984343124634957}
   _intervalTime: 0.5
+--- !u!114 &1571543004753185472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577973480899275759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24a7555773d9b44bb21c544c9557941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1577973480899420503
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/RoadGenerator/Prefabs/Road.prefab
+++ b/TrafficSimulator/Assets/RoadGenerator/Prefabs/Road.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: -8363121987229429450}
   - component: {fileID: 2968229505203983963}
   - component: {fileID: 8991514170355834578}
+  - component: {fileID: 841036290364271954}
   m_Layer: 6
   m_Name: Road
   m_TagString: Untagged
@@ -256,6 +257,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _totalFuelConsumption: 0
+--- !u!114 &841036290364271954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3821395399200801449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 459f7424166e2034e913845c8b81615f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ColorChangeSensitivityFactor: 1
+  EmissionEnabled: 0
+  ColorTransitionDuration: 0.5
+  MaxRedValue: 1
 --- !u!1 &6099411683997650963
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/RoadGenerator/Prefabs/Road.prefab
+++ b/TrafficSimulator/Assets/RoadGenerator/Prefabs/Road.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: -7222773781664253429}
   - component: {fileID: -8363121987229429450}
   - component: {fileID: 2968229505203983963}
+  - component: {fileID: 8991514170355834578}
   m_Layer: 6
   m_Name: Road
   m_TagString: Untagged
@@ -78,11 +79,13 @@ MonoBehaviour:
   _laneContainer: {fileID: 0}
   _roadNodeContainer: {fileID: 0}
   _laneNodeContainer: {fileID: 0}
+  _POIContainer: {fileID: 0}
   PathCreator: {fileID: 4211003387211000974}
   _endOfPathInstruction: 2
   Intersections: []
   _length: 0
   IsFirstRoadInClosedLoop: 0
+  POIs: []
   IsRoadClosed: 0
   _speedSignTenKPH: {fileID: 8070643699621653665, guid: 73f6f1753a0546b48867e642519b68fa, type: 3}
   _speedSignTwentyKPH: {fileID: 8070643699621653665, guid: 73f6f1753a0546b48867e642519b68fa, type: 3}
@@ -240,6 +243,19 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
+--- !u!114 &8991514170355834578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3821395399200801449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c10b2344861a73409651f16c69784b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _totalFuelConsumption: 0
 --- !u!1 &6099411683997650963
 GameObject:
   m_ObjectHideFlags: 0

--- a/TrafficSimulator/Assets/Statistics.meta
+++ b/TrafficSimulator/Assets/Statistics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b020a94cfb128db4a806c28756b0d29b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrafficSimulator/Assets/Statistics/EmissionColor.cs
+++ b/TrafficSimulator/Assets/Statistics/EmissionColor.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Statistics
+{
+    // This class handles the color change of a road based on the current fuel consumption of vehicles on that road.
+    public class EmissionColor : MonoBehaviour
+    {
+        private RoadDataGatherer _roadDataGatherer;
+        public float ColorChangeSensitivityFactor = 1.0f; // Sensitivity factor to scale the effect of fuel consumption on color change
+        public bool EmissionEnabled = false; // Enable or disable emission shader effect on the road
+        public float ColorTransitionDuration = 0.5f; // The color transition duration in seconds
+        public float MaxRedValue = 1.0f; // The value representing maximum red color
+
+        private MeshRenderer _rend;
+        private static readonly int EmissionColor1 = Shader.PropertyToID("_EmissionColor");
+
+        // Initialization of the road data gatherer and the mesh renderer components
+        private void Start()
+        {
+            _rend = GetComponent<MeshRenderer>();
+            _roadDataGatherer = GetComponent<RoadDataGatherer>();
+            StartCoroutine(RoadColorUpdate());
+        }
+
+        // Coroutine that updates the road color based on fuel consumption
+        private IEnumerator RoadColorUpdate()
+        {
+            Color currentColor = Color.green; // Initialize the road color as green
+
+            while (true)
+            {
+                Material[] materials = _rend.materials; // Get all materials attached to the road
+
+                // Calculate the colorValue based on the current fuel consumption and the sensitivity factor
+                float colorValue = _roadDataGatherer.CurrentFuelConsumption * ColorChangeSensitivityFactor;
+                colorValue = Mathf.Clamp(colorValue, 0, MaxRedValue); 
+                Color targetColor = Color.Lerp(Color.green, Color.red, colorValue); 
+
+                float timeElapsed = 0.0f;
+
+                // Transition the color smoothly over the specified duration
+                while (timeElapsed < ColorTransitionDuration)
+                {
+                    currentColor = Color.Lerp(currentColor, targetColor, timeElapsed / ColorTransitionDuration);
+
+                    foreach (Material material in materials)
+                    {
+                        if (EmissionEnabled)
+                        {
+                            material.SetColor(EmissionColor1, currentColor);
+                            material.EnableKeyword("_EMISSION");
+                        }
+                        else
+                        {
+                            material.SetColor(EmissionColor1, Color.black);
+                            material.DisableKeyword("_EMISSION");
+                        }
+                    }
+
+                    timeElapsed += Time.deltaTime;
+                    yield return null;
+                }
+            }
+        }
+    }
+}

--- a/TrafficSimulator/Assets/Statistics/EmissionColor.cs.meta
+++ b/TrafficSimulator/Assets/Statistics/EmissionColor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 459f7424166e2034e913845c8b81615f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrafficSimulator/Assets/Statistics/RoadDataGatherer.cs
+++ b/TrafficSimulator/Assets/Statistics/RoadDataGatherer.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using UnityEngine;
+using VehicleBrain;
+using CustomProperties;
+
+public class RoadDataGatherer : MonoBehaviour
+{
+    [Header("Connections")]
+    [SerializeField][ReadOnly] private float _totalFuelConsumption;
+    
+    // A list to store the registered vehicles
+    private List<GameObject> _registeredVehicles;
+    [SerializeField]public float CurrentFuelConsumption { get; private set; }
+    
+    private void Awake()
+    {
+        _registeredVehicles = new List<GameObject>();
+    }
+
+    private void Update()
+    {
+        CurrentFuelConsumption = 0;
+        foreach (GameObject vehicle in _registeredVehicles)
+            CurrentFuelConsumption += vehicle.GetComponent<FuelConsumption>().FuelConsumedSinceLastFrame;
+
+        _totalFuelConsumption += CurrentFuelConsumption;
+    }
+
+    public void RegisterVehicle(GameObject vehicle)
+    {
+        if (!_registeredVehicles.Contains(vehicle))
+            _registeredVehicles.Add(vehicle);
+    }
+
+    public void UnregisterVehicle(GameObject vehicle)
+    {
+        if (_registeredVehicles.Contains(vehicle))
+            _registeredVehicles.Remove(vehicle);
+    }
+}

--- a/TrafficSimulator/Assets/Statistics/RoadDataGatherer.cs.meta
+++ b/TrafficSimulator/Assets/Statistics/RoadDataGatherer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c10b2344861a73409651f16c69784b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrafficSimulator/Assets/Statistics/RoadRegistrator.cs
+++ b/TrafficSimulator/Assets/Statistics/RoadRegistrator.cs
@@ -1,0 +1,28 @@
+using RoadGenerator;
+using UnityEngine;
+using VehicleBrain;
+
+namespace Statistics
+{
+    [RequireComponent(typeof(AutoDrive))]
+    public class RoadRegistrator : MonoBehaviour
+    {
+        private AutoDrive _autoDrive;
+        private Road _currentRoad;
+        
+        void Awake()
+        {
+            _autoDrive = GetComponent<AutoDrive>();
+            _autoDrive.OnRoadChanged += OnRoadChanged;
+        }
+        
+        public void OnRoadChanged(Road newRoad)
+        {
+            if (_currentRoad != null)
+                _currentRoad.GetComponent<RoadDataGatherer>().UnregisterVehicle(gameObject);
+
+            _currentRoad = newRoad;
+            _currentRoad.GetComponent<RoadDataGatherer>().RegisterVehicle(gameObject);
+        }
+    }
+}

--- a/TrafficSimulator/Assets/Statistics/RoadRegistrator.cs.meta
+++ b/TrafficSimulator/Assets/Statistics/RoadRegistrator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f24a7555773d9b44bb21c544c9557941
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Applied changes from @FelixJons due to git history issues. Original description:

This pull request introduces three new classes: RoadRegistrator, RoadDataGatherer, and EmissionColor. These classes are designed to improve the traffic simulation in Unity by providing additional functionality to gather and visualize fuel consumption data on roads.

1. RoadRegistrator: This class is responsible for registering and unregistering vehicles on roads. It listens to the OnRoadChanged event from the AutoDrive component, and updates the road registration accordingly.

2. RoadDataGatherer: This class gathers fuel consumption data from vehicles registered on a road. It maintains a list of registered vehicles and calculates the current and total fuel consumption for the road.

3. EmissionColor: This class handles the color change of a road based on the current fuel consumption of vehicles on that road. It provides options to control the color change sensitivity, enable/disable emission shader effects, and set the color transition duration.

EmissionColor needs to be fine-tuned to reflect appropriate boundaries for the roads should be green and red.